### PR TITLE
 Laravel 11対応

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "krlove/eloquent-model-generator",
     "description": "Eloquent Model Generator",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "license": "MIT",
     "autoload": {
         "psr-4": {
@@ -14,16 +14,17 @@
         }
     },
     "require": {
-        "php": "^8.0",
-        "illuminate/database": "^9.0",
-        "illuminate/support": "^9.0",
-        "illuminate/config": "^9.0",
-        "illuminate/console": "^9.0",
+        "php": "^8.2",
+        "ext-pdo": "*",
+        "illuminate/database": "^11.0",
+        "illuminate/support": "^11.0",
+        "illuminate/config": "^11.0",
+        "illuminate/console": "^11.0",
         "doctrine/dbal": "^3.0",
         "krlove/code-generator": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^10.5"
     },
     "extra": {
         "laravel": {

--- a/src/Command/GenerateModelCommand.php
+++ b/src/Command/GenerateModelCommand.php
@@ -3,7 +3,7 @@
 namespace Krlove\EloquentModelGenerator\Command;
 
 use Illuminate\Console\Command;
-use Illuminate\Database\DatabaseManager;
+use Krlove\EloquentModelGenerator\CustomDatabaseManager;
 use Krlove\EloquentModelGenerator\Generator;
 use Krlove\EloquentModelGenerator\Helper\Prefix;
 use Symfony\Component\Console\Input\InputArgument;
@@ -14,7 +14,7 @@ class GenerateModelCommand extends Command
 
     protected $name = 'krlove:generate:model';
 
-    public function __construct(private Generator $generator, private DatabaseManager $databaseManager)
+    public function __construct(private Generator $generator, private CustomDatabaseManager $databaseManager)
     {
         parent::__construct();
     }

--- a/src/Command/GenerateModelsCommand.php
+++ b/src/Command/GenerateModelsCommand.php
@@ -4,7 +4,7 @@ namespace Krlove\EloquentModelGenerator\Command;
 
 use Illuminate\Config\Repository as AppConfig;
 use Illuminate\Console\Command;
-use Illuminate\Database\DatabaseManager;
+use Krlove\EloquentModelGenerator\CustomDatabaseManager;
 use Krlove\EloquentModelGenerator\Generator;
 use Krlove\EloquentModelGenerator\Helper\EmgHelper;
 use Krlove\EloquentModelGenerator\Helper\Prefix;
@@ -16,7 +16,7 @@ class GenerateModelsCommand extends Command
 
     protected $name = 'krlove:generate:models';
 
-    public function __construct(private Generator $generator, private DatabaseManager $databaseManager)
+    public function __construct(private Generator $generator, private CustomDatabaseManager $databaseManager)
     {
         parent::__construct();
     }

--- a/src/CustomDatabaseManager.php
+++ b/src/CustomDatabaseManager.php
@@ -1,0 +1,473 @@
+<?php
+
+namespace Krlove\EloquentModelGenerator;
+
+use Doctrine\DBAL\Types\Type;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Database\Events\ConnectionEstablished;
+use Illuminate\Support\Arr;
+use Illuminate\Support\ConfigurationUrlParser;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+use PDO;
+use RuntimeException;
+
+/**
+ * @mixin \Illuminate\Database\Connection
+ */
+class CustomDatabaseManager implements ConnectionResolverInterface
+{
+    use Macroable {
+        __call as macroCall;
+    }
+
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * The database connection factory instance.
+     *
+     * @var \Illuminate\Database\Connectors\ConnectionFactory
+     */
+    protected $factory;
+
+    /**
+     * The active connection instances.
+     *
+     * @var array<string, \Illuminate\Database\Connection>
+     */
+    protected $connections = [];
+
+    /**
+     * The custom connection resolvers.
+     *
+     * @var array<string, callable>
+     */
+    protected $extensions = [];
+
+    /**
+     * The callback to be executed to reconnect to a database.
+     *
+     * @var callable
+     */
+    protected $reconnector;
+
+    /**
+     * The custom Doctrine column types.
+     *
+     * @var array<string, array>
+     */
+    protected $doctrineTypes = [];
+
+    /**
+     * Create a new database manager instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Database\Connectors\ConnectionFactory  $factory
+     * @return void
+     */
+    public function __construct($app, ConnectionFactory $factory)
+    {
+        $this->app = $app;
+        $this->factory = $factory;
+
+        $this->reconnector = function ($connection) {
+            $this->reconnect($connection->getNameWithReadWriteType());
+        };
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @param  string|null  $name
+     * @return \Illuminate\Database\Connection
+     */
+    public function connection($name = null)
+    {
+        [$database, $type] = $this->parseConnectionName($name);
+
+        $name = $name ?: $database;
+
+        // If we haven't created this connection, we'll create it based on the config
+        // provided in the application. Once we've created the connections we will
+        // set the "fetch mode" for PDO which determines the query return types.
+        if (! isset($this->connections[$name])) {
+            $this->connections[$name] = $this->configure(
+                $this->makeConnection($database), $type
+            );
+
+            if ($this->app->bound('events')) {
+                $this->app['events']->dispatch(
+                    new ConnectionEstablished($this->connections[$name])
+                );
+            }
+        }
+
+        return $this->connections[$name];
+    }
+
+    /**
+     * Parse the connection into an array of the name and read / write type.
+     *
+     * @param  string  $name
+     * @return array
+     */
+    protected function parseConnectionName($name)
+    {
+        $name = $name ?: $this->getDefaultConnection();
+
+        return Str::endsWith($name, ['::read', '::write'])
+                            ? explode('::', $name, 2) : [$name, null];
+    }
+
+    /**
+     * Make the database connection instance.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Database\Connection
+     */
+    protected function makeConnection($name)
+    {
+        $config = $this->configuration($name);
+
+        // First we will check by the connection name to see if an extension has been
+        // registered specifically for that connection. If it has we will call the
+        // Closure and pass it the config allowing it to resolve the connection.
+        if (isset($this->extensions[$name])) {
+            return call_user_func($this->extensions[$name], $config, $name);
+        }
+
+        // Next we will check to see if an extension has been registered for a driver
+        // and will call the Closure if so, which allows us to have a more generic
+        // resolver for the drivers themselves which applies to all connections.
+        if (isset($this->extensions[$driver = $config['driver']])) {
+            return call_user_func($this->extensions[$driver], $config, $name);
+        }
+
+        return $this->factory->make($config, $name);
+    }
+
+    /**
+     * Get the configuration for a connection.
+     *
+     * @param  string  $name
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function configuration($name)
+    {
+        $name = $name ?: $this->getDefaultConnection();
+
+        // To get the database connection configuration, we will just pull each of the
+        // connection configurations and get the configurations for the given name.
+        // If the configuration doesn't exist, we'll throw an exception and bail.
+        $connections = $this->app['config']['database.connections'];
+
+        if (is_null($config = Arr::get($connections, $name))) {
+            throw new InvalidArgumentException("Database connection [{$name}] not configured.");
+        }
+
+        return (new ConfigurationUrlParser)
+                    ->parseConfiguration($config);
+    }
+
+    /**
+     * Prepare the database connection instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $type
+     * @return \Illuminate\Database\Connection
+     */
+    protected function configure(\Illuminate\Database\Connection $connection, $type)
+    {
+        $connection = $this->setPdoForType($connection, $type)->setReadWriteType($type);
+
+        // First we'll set the fetch mode and a few other dependencies of the database
+        // connection. This method basically just configures and prepares it to get
+        // used by the application. Once we're finished we'll return it back out.
+        if ($this->app->bound('events')) {
+            $connection->setEventDispatcher($this->app['events']);
+        }
+
+        if ($this->app->bound('db.transactions')) {
+            $connection->setTransactionManager($this->app['db.transactions']);
+        }
+
+        // Here we'll set a reconnector callback. This reconnector can be any callable
+        // so we will set a Closure to reconnect from this manager with the name of
+        // the connection, which will allow us to reconnect from the connections.
+        $connection->setReconnector($this->reconnector);
+
+        $this->registerConfiguredDoctrineTypes($connection);
+
+        return $connection;
+    }
+
+    /**
+     * Prepare the read / write mode for database connection instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string|null  $type
+     * @return \Illuminate\Database\Connection
+     */
+    protected function setPdoForType(Connection $connection, $type = null)
+    {
+        if ($type === 'read') {
+            $connection->setPdo($connection->getReadPdo());
+        } elseif ($type === 'write') {
+            $connection->setReadPdo($connection->getPdo());
+        }
+
+        return $connection;
+    }
+
+    /**
+     * Register custom Doctrine types with the connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    protected function registerConfiguredDoctrineTypes(Connection $connection): void
+    {
+        foreach ($this->app['config']->get('database.dbal.types', []) as $name => $class) {
+            $this->registerDoctrineType($class, $name, $name);
+        }
+
+        foreach ($this->doctrineTypes as $name => [$type, $class]) {
+            $connection->registerDoctrineType($class, $name, $type);
+        }
+    }
+
+    /**
+     * Register a custom Doctrine type.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @param  string  $type
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \RuntimeException
+     */
+    public function registerDoctrineType(string $class, string $name, string $type): void
+    {
+        if (! class_exists('Doctrine\DBAL\Connection')) {
+            throw new RuntimeException(
+                'Registering a custom Doctrine type requires Doctrine DBAL (doctrine/dbal).'
+            );
+        }
+
+        if (! Type::hasType($name)) {
+            Type::addType($name, $class);
+        }
+
+        $this->doctrineTypes[$name] = [$type, $class];
+    }
+
+    /**
+     * Disconnect from the given database and remove from local cache.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function purge($name = null)
+    {
+        $name = $name ?: $this->getDefaultConnection();
+
+        $this->disconnect($name);
+
+        unset($this->connections[$name]);
+    }
+
+    /**
+     * Disconnect from the given database.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function disconnect($name = null)
+    {
+        if (isset($this->connections[$name = $name ?: $this->getDefaultConnection()])) {
+            $this->connections[$name]->disconnect();
+        }
+    }
+
+    /**
+     * Reconnect to the given database.
+     *
+     * @param  string|null  $name
+     * @return \Illuminate\Database\Connection
+     */
+    public function reconnect($name = null)
+    {
+        $this->disconnect($name = $name ?: $this->getDefaultConnection());
+
+        if (! isset($this->connections[$name])) {
+            return $this->connection($name);
+        }
+
+        return $this->refreshPdoConnections($name);
+    }
+
+    /**
+     * Set the default database connection for the callback execution.
+     *
+     * @param  string  $name
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function usingConnection($name, callable $callback)
+    {
+        $previousName = $this->getDefaultConnection();
+
+        $this->setDefaultConnection($name);
+
+        return tap($callback(), function () use ($previousName) {
+            $this->setDefaultConnection($previousName);
+        });
+    }
+
+    /**
+     * Refresh the PDO connections on a given connection.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Database\Connection
+     */
+    protected function refreshPdoConnections($name)
+    {
+        [$database, $type] = $this->parseConnectionName($name);
+
+        $fresh = $this->configure(
+            $this->makeConnection($database), $type
+        );
+
+        return $this->connections[$name]
+                    ->setPdo($fresh->getRawPdo())
+                    ->setReadPdo($fresh->getRawReadPdo());
+    }
+
+    /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    public function getDefaultConnection()
+    {
+        return $this->app['config']['database.default'];
+    }
+
+    /**
+     * Set the default connection name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setDefaultConnection($name)
+    {
+        $this->app['config']['database.default'] = $name;
+    }
+
+    /**
+     * Get all of the support drivers.
+     *
+     * @return string[]
+     */
+    public function supportedDrivers()
+    {
+        return ['mysql', 'pgsql', 'sqlite', 'sqlsrv'];
+    }
+
+    /**
+     * Get all of the drivers that are actually available.
+     *
+     * @return string[]
+     */
+    public function availableDrivers()
+    {
+        return array_intersect(
+            $this->supportedDrivers(),
+            str_replace('dblib', 'sqlsrv', PDO::getAvailableDrivers())
+        );
+    }
+
+    /**
+     * Register an extension connection resolver.
+     *
+     * @param  string  $name
+     * @param  callable  $resolver
+     * @return void
+     */
+    public function extend($name, callable $resolver)
+    {
+        $this->extensions[$name] = $resolver;
+    }
+
+    /**
+     * Remove an extension connection resolver.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function forgetExtension($name)
+    {
+        unset($this->extensions[$name]);
+    }
+
+    /**
+     * Return all of the created connections.
+     *
+     * @return array<string, \Illuminate\Database\Connection>
+     */
+    public function getConnections()
+    {
+        return $this->connections;
+    }
+
+    /**
+     * Set the database reconnector callback.
+     *
+     * @param  callable  $reconnector
+     * @return void
+     */
+    public function setReconnector(callable $reconnector)
+    {
+        $this->reconnector = $reconnector;
+    }
+
+    /**
+     * Set the application instance used by the manager.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return $this
+     */
+    public function setApplication($app)
+    {
+        $this->app = $app;
+
+        return $this;
+    }
+
+    /**
+     * Dynamically pass methods to the default connection.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        return $this->connection()->$method(...$parameters);
+    }
+}

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -1,0 +1,472 @@
+<?php
+
+namespace Krlove\EloquentModelGenerator;
+
+use Doctrine\DBAL\Types\Type;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Database\Events\ConnectionEstablished;
+use Illuminate\Support\Arr;
+use Illuminate\Support\ConfigurationUrlParser;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+use PDO;
+use RuntimeException;
+
+/**
+ * @mixin \Illuminate\Database\Connection
+ */
+class DatabaseManager implements ConnectionResolverInterface
+{
+    use Macroable {
+        __call as macroCall;
+    }
+
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * The database connection factory instance.
+     *
+     * @var \Illuminate\Database\Connectors\ConnectionFactory
+     */
+    protected $factory;
+
+    /**
+     * The active connection instances.
+     *
+     * @var array<string, \Illuminate\Database\Connection>
+     */
+    protected $connections = [];
+
+    /**
+     * The custom connection resolvers.
+     *
+     * @var array<string, callable>
+     */
+    protected $extensions = [];
+
+    /**
+     * The callback to be executed to reconnect to a database.
+     *
+     * @var callable
+     */
+    protected $reconnector;
+
+    /**
+     * The custom Doctrine column types.
+     *
+     * @var array<string, array>
+     */
+    protected $doctrineTypes = [];
+
+    /**
+     * Create a new database manager instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Database\Connectors\ConnectionFactory  $factory
+     * @return void
+     */
+    public function __construct($app, ConnectionFactory $factory)
+    {
+        $this->app = $app;
+        $this->factory = $factory;
+
+        $this->reconnector = function ($connection) {
+            $this->reconnect($connection->getNameWithReadWriteType());
+        };
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @param  string|null  $name
+     * @return \Illuminate\Database\Connection
+     */
+    public function connection($name = null)
+    {
+        [$database, $type] = $this->parseConnectionName($name);
+
+        $name = $name ?: $database;
+
+        // If we haven't created this connection, we'll create it based on the config
+        // provided in the application. Once we've created the connections we will
+        // set the "fetch mode" for PDO which determines the query return types.
+        if (! isset($this->connections[$name])) {
+            $this->connections[$name] = $this->configure(
+                $this->makeConnection($database), $type
+            );
+
+            if ($this->app->bound('events')) {
+                $this->app['events']->dispatch(
+                    new ConnectionEstablished($this->connections[$name])
+                );
+            }
+        }
+
+        return $this->connections[$name];
+    }
+
+    /**
+     * Parse the connection into an array of the name and read / write type.
+     *
+     * @param  string  $name
+     * @return array
+     */
+    protected function parseConnectionName($name)
+    {
+        $name = $name ?: $this->getDefaultConnection();
+
+        return Str::endsWith($name, ['::read', '::write'])
+                            ? explode('::', $name, 2) : [$name, null];
+    }
+
+    /**
+     * Make the database connection instance.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Database\Connection
+     */
+    protected function makeConnection($name)
+    {
+        $config = $this->configuration($name);
+
+        // First we will check by the connection name to see if an extension has been
+        // registered specifically for that connection. If it has we will call the
+        // Closure and pass it the config allowing it to resolve the connection.
+        if (isset($this->extensions[$name])) {
+            return call_user_func($this->extensions[$name], $config, $name);
+        }
+
+        // Next we will check to see if an extension has been registered for a driver
+        // and will call the Closure if so, which allows us to have a more generic
+        // resolver for the drivers themselves which applies to all connections.
+        if (isset($this->extensions[$driver = $config['driver']])) {
+            return call_user_func($this->extensions[$driver], $config, $name);
+        }
+
+        return $this->factory->make($config, $name);
+    }
+
+    /**
+     * Get the configuration for a connection.
+     *
+     * @param  string  $name
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function configuration($name)
+    {
+        $name = $name ?: $this->getDefaultConnection();
+
+        // To get the database connection configuration, we will just pull each of the
+        // connection configurations and get the configurations for the given name.
+        // If the configuration doesn't exist, we'll throw an exception and bail.
+        $connections = $this->app['config']['database.connections'];
+
+        if (is_null($config = Arr::get($connections, $name))) {
+            throw new InvalidArgumentException("Database connection [{$name}] not configured.");
+        }
+
+        return (new ConfigurationUrlParser)
+                    ->parseConfiguration($config);
+    }
+
+    /**
+     * Prepare the database connection instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $type
+     * @return \Illuminate\Database\Connection
+     */
+    protected function configure(Connection $connection, $type)
+    {
+        $connection = $this->setPdoForType($connection, $type)->setReadWriteType($type);
+
+        // First we'll set the fetch mode and a few other dependencies of the database
+        // connection. This method basically just configures and prepares it to get
+        // used by the application. Once we're finished we'll return it back out.
+        if ($this->app->bound('events')) {
+            $connection->setEventDispatcher($this->app['events']);
+        }
+
+        if ($this->app->bound('db.transactions')) {
+            $connection->setTransactionManager($this->app['db.transactions']);
+        }
+
+        // Here we'll set a reconnector callback. This reconnector can be any callable
+        // so we will set a Closure to reconnect from this manager with the name of
+        // the connection, which will allow us to reconnect from the connections.
+        $connection->setReconnector($this->reconnector);
+
+        $this->registerConfiguredDoctrineTypes($connection);
+
+        return $connection;
+    }
+
+    /**
+     * Prepare the read / write mode for database connection instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string|null  $type
+     * @return \Illuminate\Database\Connection
+     */
+    protected function setPdoForType(Connection $connection, $type = null)
+    {
+        if ($type === 'read') {
+            $connection->setPdo($connection->getReadPdo());
+        } elseif ($type === 'write') {
+            $connection->setReadPdo($connection->getPdo());
+        }
+
+        return $connection;
+    }
+
+    /**
+     * Register custom Doctrine types with the connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    protected function registerConfiguredDoctrineTypes(Connection $connection): void
+    {
+        foreach ($this->app['config']->get('database.dbal.types', []) as $name => $class) {
+            $this->registerDoctrineType($class, $name, $name);
+        }
+
+        foreach ($this->doctrineTypes as $name => [$type, $class]) {
+            $connection->registerDoctrineType($class, $name, $type);
+        }
+    }
+
+    /**
+     * Register a custom Doctrine type.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @param  string  $type
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \RuntimeException
+     */
+    public function registerDoctrineType(string $class, string $name, string $type): void
+    {
+        if (! class_exists('Doctrine\DBAL\Connection')) {
+            throw new RuntimeException(
+                'Registering a custom Doctrine type requires Doctrine DBAL (doctrine/dbal).'
+            );
+        }
+
+        if (! Type::hasType($name)) {
+            Type::addType($name, $class);
+        }
+
+        $this->doctrineTypes[$name] = [$type, $class];
+    }
+
+    /**
+     * Disconnect from the given database and remove from local cache.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function purge($name = null)
+    {
+        $name = $name ?: $this->getDefaultConnection();
+
+        $this->disconnect($name);
+
+        unset($this->connections[$name]);
+    }
+
+    /**
+     * Disconnect from the given database.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function disconnect($name = null)
+    {
+        if (isset($this->connections[$name = $name ?: $this->getDefaultConnection()])) {
+            $this->connections[$name]->disconnect();
+        }
+    }
+
+    /**
+     * Reconnect to the given database.
+     *
+     * @param  string|null  $name
+     * @return \Illuminate\Database\Connection
+     */
+    public function reconnect($name = null)
+    {
+        $this->disconnect($name = $name ?: $this->getDefaultConnection());
+
+        if (! isset($this->connections[$name])) {
+            return $this->connection($name);
+        }
+
+        return $this->refreshPdoConnections($name);
+    }
+
+    /**
+     * Set the default database connection for the callback execution.
+     *
+     * @param  string  $name
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function usingConnection($name, callable $callback)
+    {
+        $previousName = $this->getDefaultConnection();
+
+        $this->setDefaultConnection($name);
+
+        return tap($callback(), function () use ($previousName) {
+            $this->setDefaultConnection($previousName);
+        });
+    }
+
+    /**
+     * Refresh the PDO connections on a given connection.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Database\Connection
+     */
+    protected function refreshPdoConnections($name)
+    {
+        [$database, $type] = $this->parseConnectionName($name);
+
+        $fresh = $this->configure(
+            $this->makeConnection($database), $type
+        );
+
+        return $this->connections[$name]
+                    ->setPdo($fresh->getRawPdo())
+                    ->setReadPdo($fresh->getRawReadPdo());
+    }
+
+    /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    public function getDefaultConnection()
+    {
+        return $this->app['config']['database.default'];
+    }
+
+    /**
+     * Set the default connection name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setDefaultConnection($name)
+    {
+        $this->app['config']['database.default'] = $name;
+    }
+
+    /**
+     * Get all of the support drivers.
+     *
+     * @return string[]
+     */
+    public function supportedDrivers()
+    {
+        return ['mysql', 'pgsql', 'sqlite', 'sqlsrv'];
+    }
+
+    /**
+     * Get all of the drivers that are actually available.
+     *
+     * @return string[]
+     */
+    public function availableDrivers()
+    {
+        return array_intersect(
+            $this->supportedDrivers(),
+            str_replace('dblib', 'sqlsrv', PDO::getAvailableDrivers())
+        );
+    }
+
+    /**
+     * Register an extension connection resolver.
+     *
+     * @param  string  $name
+     * @param  callable  $resolver
+     * @return void
+     */
+    public function extend($name, callable $resolver)
+    {
+        $this->extensions[$name] = $resolver;
+    }
+
+    /**
+     * Remove an extension connection resolver.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function forgetExtension($name)
+    {
+        unset($this->extensions[$name]);
+    }
+
+    /**
+     * Return all of the created connections.
+     *
+     * @return array<string, \Illuminate\Database\Connection>
+     */
+    public function getConnections()
+    {
+        return $this->connections;
+    }
+
+    /**
+     * Set the database reconnector callback.
+     *
+     * @param  callable  $reconnector
+     * @return void
+     */
+    public function setReconnector(callable $reconnector)
+    {
+        $this->reconnector = $reconnector;
+    }
+
+    /**
+     * Set the application instance used by the manager.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return $this
+     */
+    public function setApplication($app)
+    {
+        $this->app = $app;
+
+        return $this;
+    }
+
+    /**
+     * Dynamically pass methods to the default connection.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        return $this->connection()->$method(...$parameters);
+    }
+}

--- a/src/Processor/CustomPrimaryKeyProcessor.php
+++ b/src/Processor/CustomPrimaryKeyProcessor.php
@@ -2,9 +2,9 @@
 
 namespace Krlove\EloquentModelGenerator\Processor;
 
-use Illuminate\Database\DatabaseManager;
 use Krlove\CodeGenerator\Model\DocBlockModel;
 use Krlove\CodeGenerator\Model\PropertyModel;
+use Krlove\EloquentModelGenerator\CustomDatabaseManager;
 use Krlove\EloquentModelGenerator\Config\Config;
 use Krlove\EloquentModelGenerator\Helper\Prefix;
 use Krlove\EloquentModelGenerator\Model\EloquentModel;
@@ -12,7 +12,7 @@ use Krlove\EloquentModelGenerator\TypeRegistry;
 
 class CustomPrimaryKeyProcessor implements ProcessorInterface
 {
-    public function __construct(private DatabaseManager $databaseManager, private TypeRegistry $typeRegistry) {}
+    public function __construct(private CustomDatabaseManager $databaseManager, private TypeRegistry $typeRegistry) {}
 
     public function process(EloquentModel $model, Config $config): void
     {

--- a/src/Processor/FieldProcessor.php
+++ b/src/Processor/FieldProcessor.php
@@ -2,7 +2,7 @@
 
 namespace Krlove\EloquentModelGenerator\Processor;
 
-use Illuminate\Database\DatabaseManager;
+use Krlove\EloquentModelGenerator\CustomDatabaseManager;
 use Krlove\CodeGenerator\Model\DocBlockModel;
 use Krlove\CodeGenerator\Model\PropertyModel;
 use Krlove\CodeGenerator\Model\VirtualPropertyModel;
@@ -13,7 +13,7 @@ use Krlove\EloquentModelGenerator\TypeRegistry;
 
 class FieldProcessor implements ProcessorInterface
 {
-    public function __construct(private DatabaseManager $databaseManager, private TypeRegistry $typeRegistry) {}
+    public function __construct(private CustomDatabaseManager $databaseManager, private TypeRegistry $typeRegistry) {}
     
     public function process(EloquentModel $model, Config $config): void
     {

--- a/src/Processor/RelationProcessor.php
+++ b/src/Processor/RelationProcessor.php
@@ -2,7 +2,7 @@
 
 namespace Krlove\EloquentModelGenerator\Processor;
 
-use Illuminate\Database\DatabaseManager;
+use Krlove\EloquentModelGenerator\CustomDatabaseManager;
 use Krlove\EloquentModelGenerator\Config\Config;
 use Krlove\EloquentModelGenerator\Helper\EmgHelper;
 use Krlove\EloquentModelGenerator\Helper\Prefix;
@@ -14,7 +14,7 @@ use Krlove\EloquentModelGenerator\Model\HasOne;
 
 class RelationProcessor implements ProcessorInterface
 {
-    public function __construct(private DatabaseManager $databaseManager) {}
+    public function __construct(private CustomDatabaseManager $databaseManager) {}
 
     public function process(EloquentModel $model, Config $config): void
     {

--- a/src/Processor/TableNameProcessor.php
+++ b/src/Processor/TableNameProcessor.php
@@ -2,7 +2,7 @@
 
 namespace Krlove\EloquentModelGenerator\Processor;
 
-use Illuminate\Database\DatabaseManager;
+use Krlove\EloquentModelGenerator\CustomDatabaseManager;
 use Krlove\CodeGenerator\Model\ClassNameModel;
 use Krlove\CodeGenerator\Model\DocBlockModel;
 use Krlove\CodeGenerator\Model\PropertyModel;
@@ -15,7 +15,7 @@ use Krlove\EloquentModelGenerator\Model\EloquentModel;
 
 class TableNameProcessor implements ProcessorInterface
 {
-    public function __construct(private DatabaseManager $databaseManager) {}
+    public function __construct(private CustomDatabaseManager $databaseManager) {}
 
     public function process(EloquentModel $model, Config $config): void
     {

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -2,7 +2,7 @@
 
 namespace Krlove\EloquentModelGenerator;
 
-use Illuminate\Database\DatabaseManager;
+use Krlove\EloquentModelGenerator\CustomDatabaseManager;
 
 class TypeRegistry
 {
@@ -29,28 +29,18 @@ class TypeRegistry
         'enum'         => 'string',
     ];
 
-    public function __construct(private DatabaseManager $databaseManager)
-    {
-        foreach ($this->types as $sqlType => $phpType) {
-            $this->registerDoctrineTypeMapping($sqlType, $phpType);
-        }
-    }
+    public function __construct(private CustomDatabaseManager $databaseManager) {}
 
-    public function registerType(string $sqlType, string $phpType, string $connection = null): void
+    public function registerType(string $type, string $value, string $connection = null): void
     {
-        $this->types[$sqlType] = $phpType;
+        $this->types[$type] = $value;
 
-        $this->registerDoctrineTypeMapping($sqlType, $phpType, $connection);
+        $manager = $this->databaseManager->connection($connection)->getDoctrineSchemaManager();
+        $manager->getDatabasePlatform()->registerDoctrineTypeMapping($type, $value);
     }
 
     public function resolveType(string $type): string
     {
         return array_key_exists($type, $this->types) ? $this->types[$type] : 'mixed';
-    }
-
-    private function registerDoctrineTypeMapping(string $sqlType, string $phpType, string $connection = null): void
-    {
-        $manager = $this->databaseManager->connection($connection)->getDoctrineSchemaManager();
-        $manager->getDatabasePlatform()->registerDoctrineTypeMapping($sqlType, $phpType);
     }
 }

--- a/tests/integration/GeneratorTest.php
+++ b/tests/integration/GeneratorTest.php
@@ -3,7 +3,7 @@
 namespace Krlove\Tests\Integration;
 
 use Illuminate\Database\Connectors\SQLiteConnector;
-use Illuminate\Database\DatabaseManager;
+use Krlove\EloquentModelGenerator\CustomDatabaseManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\SQLiteConnection;
 use Krlove\EloquentModelGenerator\Config\Config;
@@ -40,7 +40,7 @@ class GeneratorTest extends TestCase
 
     protected function setUp(): void
     {
-        $databaseManagerMock = $this->createMock(DatabaseManager::class);
+        $databaseManagerMock = $this->createMock(CustomDatabaseManager::class);
         $databaseManagerMock->expects($this->any())
             ->method('connection')
             ->willReturn(self::$connection);


### PR DESCRIPTION
## 注意
- [x] [backend側PR](https://github.com/WORKSJAPAN/e2RProCloud-backend/pull/1007)をマージしてから、このPRをマージする

## 変更点
[前回作ったPR](https://github.com/WORKSJAPAN/eloquent-model-generator/pull/1)に未署名コミットが含まれていて再署名が困難だったので、下記コマンドを実行して差分を取り込みつつPR作成しなおしました。

```sh
# laravel11-compatibility = このPRのブランチ
# l11-compatibility = 以前作ったPRのブランチ
git checkout 2dev
git checkout -b laravel11-compatibility
git checkout l11-compatibility -- .
```

- [x] backend側の動作テスト実施
- [x] 依存関係のアップデート
- [x] `illuminate/database` に依存しないようモデル生成に関連するクラスを改修